### PR TITLE
Adding paper-toast

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "paper-spinner": "PolymerElements/paper-spinner",
     "paper-swatch-picker": "PolymerElements/paper-swatch-picker",
     "paper-tabs": "PolymerElements/paper-tabs",
+    "paper-toast": "PolymerElements/paper-toast",
     "paper-toolbar": "PolymerElements/paper-toolbar",
     "paper-tooltip": "PolymerElements/paper-tooltip"
   }


### PR DESCRIPTION
`paper-toast` is currently isolated in Webcomponents.org, i.e. it ins't included in `paper-ui-elements` or any other `paper`related collection. And IMHO it shoudl be, as it's a paper UI element.