### PR TITLE
remove paper-menu

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,19 +8,18 @@
   ],
   "license": "http://polymer.github.io/LICENSE.txt",
   "dependencies": {
-    "paper-button": "PolymerElements/paper-button",
-    "paper-badge": "PolymerElements/paper-badge",
-    "paper-card": "PolymerElements/paper-card",
-    "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu",
-    "paper-icon-button": "PolymerElements/paper-icon-button",
-    "paper-item": "PolymerElements/paper-item",
-    "paper-menu": "PolymerElements/paper-menu",
-    "paper-menu-button": "PolymerElements/paper-menu-button",
-    "paper-progress": "PolymerElements/paper-progress",
-    "paper-spinner": "PolymerElements/paper-spinner",
-    "paper-swatch-picker": "PolymerElements/paper-swatch-picker",
-    "paper-tabs": "PolymerElements/paper-tabs",
-    "paper-toolbar": "PolymerElements/paper-toolbar",
-    "paper-tooltip": "PolymerElements/paper-tooltip"
+    "paper-button": "PolymerElements/paper-button#*",
+    "paper-badge": "PolymerElements/paper-badge#*",
+    "paper-card": "PolymerElements/paper-card#*",
+    "paper-dropdown-menu": "PolymerElements/paper-dropdown-menu#*",
+    "paper-icon-button": "PolymerElements/paper-icon-button#*",
+    "paper-item": "PolymerElements/paper-item#*",
+    "paper-menu-button": "PolymerElements/paper-menu-button#*",
+    "paper-progress": "PolymerElements/paper-progress#*",
+    "paper-spinner": "PolymerElements/paper-spinner#*",
+    "paper-swatch-picker": "PolymerElements/paper-swatch-picker#*",
+    "paper-tabs": "PolymerElements/paper-tabs#*",
+    "paper-toolbar": "PolymerElements/paper-toolbar#*",
+    "paper-tooltip": "PolymerElements/paper-tooltip#*"
   }
 }


### PR DESCRIPTION
`paper-menu` hasn't been ported to hybrid so it completely hoses all the dependencies by pinning Polymer to 1.0. This fixes that.

(as a bonus I just added some `#*` everywhere to make it consistent with the other repos)